### PR TITLE
Fix "go style" install in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run command on git repositories in parallel.
 
 ### Go style
 
-    go get github.com/jcgay/parallel-git-repo
+    go install github.com/jcgay/parallel-git-repo@latest
 
 ## Configuration
 


### PR DESCRIPTION
 `go install` is the new `go get`! 

See https://go.dev/doc/go-get-install-deprecation:

> In Go 1.18, go get will no longer build packages