### PR TITLE
Bump Go directive to 1.24

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jcgay/parallel-git-repo
 
-go 1.20
+go 1.24
 
 require (
 	github.com/assertgo/assert v2.0.0+incompatible


### PR DESCRIPTION
## Why

Go 1.20 reached end of life in August 2023 and no longer receives security fixes. This moves the module to a currently supported Go version.

No source changes required — `go test ./...` and `go vet ./...` pass unchanged.

> Note: the CI workflow still pins `1.20.1`; that is updated in the next PR (CI modernization).

🤖 Generated with [Claude Code](https://claude.com/claude-code)