### PR TITLE
Modernize GitHub Actions CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -11,15 +11,21 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.20.1
+        go-version-file: go.mod
 
     - name: Build
       run: make build
 
+    - name: Vet
+      run: go vet ./...
+
     - name: Test
       run: make test
+
+    - name: Vulnerability check
+      run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,6 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
+      - uses: release-drafter/release-drafter@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Why

The CI ran on archived actions (deprecation warnings) and only built + tested — regressions caught by `vet` or known CVEs went unnoticed.

## Changes

- `actions/checkout` v2 → v4, `actions/setup-go` v2 → v5 (v2 run on end-of-life Node 16).
- Read the Go version from `go.mod` (`go-version-file`) instead of hand-pinning `1.20.1`.
- Add a **vet** step — calls `go vet ./...` directly, not `make vet`, because the Makefile target pipes through `tee` and always exits 0 (would let vet failures pass CI). The Makefile bug is tracked for the docs/Makefile cleanup PR.
- Add a **govulncheck** step so known vulnerabilities fail the build.
- `release-drafter` v5 → v6.

Verified `make build`, `go vet ./...`, `make test`, and `govulncheck ./...` locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)