### PR TITLE
Fix stale links and badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,13 @@ Run command on git repositories in parallel.
 
 ## Installation
 
+### Homebrew
+
+    brew install jcgay/jcgay/parallel-git-repo
+
 ### Binaries
 
- - [macOS (64 bits)](https://bintray.com/jcgay/tools/download_file?file_path=v1.0.1%2Fparallel-git-repo-darwin-amd64)
- - Linux: [32 bits](https://bintray.com/jcgay/tools/download_file?file_path=v1.0.1%2Fparallel-git-repo-linux-386) / [64 bits](https://bintray.com/jcgay/tools/download_file?file_path=v1.0.1%2Fparallel-git-repo-linux-amd64)
- - [Windows (64 bits)](https://bintray.com/jcgay/tools/download_file?file_path=v1.0.1%2Fparallel-git-repo-windows-amd64)
+Download the archive for your platform from the [latest release](https://github.com/jcgay/parallel-git-repo/releases/latest).
 
 ### Go style
 
@@ -86,13 +88,15 @@ maven-notifier: ✔
 
 ### Status
 
-[![Build Status](https://travis-ci.org/jcgay/parallel-git-repo.svg?branch=master)](https://travis-ci.org/jcgay/parallel-git-repo)
+[![Build Status](https://github.com/jcgay/parallel-git-repo/actions/workflows/go.yml/badge.svg)](https://github.com/jcgay/parallel-git-repo/actions/workflows/go.yml)
 [![Code Report](https://goreportcard.com/badge/github.com/jcgay/parallel-git-repo)](https://goreportcard.com/report/github.com/jcgay/parallel-git-repo)
-[![Coverage Status](https://coveralls.io/repos/github/jcgay/parallel-git-repo/badge.svg?branch=master)](https://coveralls.io/github/jcgay/parallel-git-repo?branch=master)
 
 ### Release
 
-    make release
+Push a tag; the release workflow builds the binaries with [GoReleaser](https://goreleaser.com) and publishes them to GitHub Releases:
+
+    make tag
+    git push origin <version>
 
 ### List available tasks
 


### PR DESCRIPTION
## Why

The install and status sections pointed at dead services and a removed make target.

## Changes

- **Binary links** pointed at **Bintray (shut down May 2021)** — none worked. Now point to the [GitHub Releases](https://github.com/jcgay/parallel-git-repo/releases/latest) page that GoReleaser populates.
- **Added Homebrew install** (`brew install jcgay/jcgay/parallel-git-repo`), now that releases publish a formula to the tap.
- **Badges**: replaced the dead Travis CI badge with the GitHub Actions badge; removed the Coveralls badge (no coverage is uploaded). Kept Go Report Card.
- **Release section** referenced the removed `make release`; documents the tag-based GoReleaser flow instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)