### PR TITLE
Exit with a non-zero status when a command fails

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/fatih/color"
 	"github.com/mitchellh/go-homedir"
@@ -119,8 +120,8 @@ func main() {
 				fmt.Printf("  - %s\n", repo)
 			}
 		}
-	} else {
-		runCommand(configuration, args, group)
+	} else if runCommand(configuration, args, group) > 0 {
+		os.Exit(1)
 	}
 }
 
@@ -147,7 +148,7 @@ func listCommands() string {
 	return result
 }
 
-func runCommand(config *configuration, args []string, group string) {
+func runCommand(config *configuration, args []string, group string) int {
 	commandName := args[0]
 	var toExec []string
 	if commandName == "run" {
@@ -161,7 +162,7 @@ func runCommand(config *configuration, args []string, group string) {
 	}
 
 	runner := newRunner(&run{ToExec: toExec, Quiet: quiet}, config)
-	runner.Run(args[1:], group)
+	return runner.Run(args[1:], group)
 }
 
 type repositories interface {
@@ -241,10 +242,13 @@ func newRunner(command runnableCommand, repos repositories) *runner {
 	}
 }
 
-func (runner *runner) Run(args []string, group string) {
+func (runner *runner) Run(args []string, group string) int {
+	var failures atomic.Int32
+	found := false
 	wg := sync.WaitGroup{}
 	for key, repos := range runner.repos.ListRepositories() {
 		if key == group {
+			found = true
 			for _, repo := range repos {
 				wg.Add(1)
 				go func(repo string) {
@@ -256,6 +260,9 @@ func (runner *runner) Run(args []string, group string) {
 					command.Stderr = output
 					command.Dir = repo
 					err := command.Run()
+					if err != nil {
+						failures.Add(1)
+					}
 
 					fmt.Fprintln(runner.writer, filepath.Base(repo)+": "+runner.runnableCommand.Output(strings.TrimSpace(output.String()), err))
 				}(repo)
@@ -263,6 +270,12 @@ func (runner *runner) Run(args []string, group string) {
 		}
 	}
 	wg.Wait()
+
+	if !found {
+		fmt.Fprintf(os.Stderr, "Unknown group %q, run `list` to show available groups.\n", group)
+		return 1
+	}
+	return int(failures.Load())
 }
 
 var option = regexp.MustCompile(`\$([0-9]+)`)

--- a/main_test.go
+++ b/main_test.go
@@ -99,6 +99,44 @@ func TestRunCommandWithIndexedArguments(t *testing.T) {
 	assertEqual(t, output.String(), repos.Dir()+": first path/10 option=third 4-7\n")
 }
 
+type FailingCommand struct{}
+
+func (command *FailingCommand) Executable() string { return "false" }
+
+func (command *FailingCommand) Options() []string { return []string{} }
+
+func (command *FailingCommand) Output(output string, err error) string { return "" }
+
+func TestRunReturnsFailureCount(t *testing.T) {
+	repos := &SingleTempRepository{}
+	runner := newRunner(&FailingCommand{}, repos)
+	runner.writer = new(bytes.Buffer)
+
+	if failures := runner.Run(nil, "default"); failures != 1 {
+		t.Errorf("got %d failures, want 1", failures)
+	}
+}
+
+func TestRunSucceedsWithZeroFailures(t *testing.T) {
+	repos := &SingleTempRepository{}
+	runner := newRunner(&PrintArgumentsCommand{}, repos)
+	runner.writer = new(bytes.Buffer)
+
+	if failures := runner.Run(nil, "default"); failures != 0 {
+		t.Errorf("got %d failures, want 0", failures)
+	}
+}
+
+func TestRunUnknownGroupIsAFailure(t *testing.T) {
+	repos := &SingleTempRepository{}
+	runner := newRunner(&PrintArgumentsCommand{}, repos)
+	runner.writer = new(bytes.Buffer)
+
+	if failures := runner.Run(nil, "does-not-exist"); failures == 0 {
+		t.Error("got 0 failures for an unknown group, want non-zero")
+	}
+}
+
 func TestForwardArgsLeavesPlaceholderWhenArgumentIsMissing(t *testing.T) {
 	result := forwardArgs([]string{"$1", "$3"}, []string{"only-first"})
 


### PR DESCRIPTION
## Why

The process always exited `0`, even when the command failed in every repository (#40). That makes the tool impossible to script or use in CI — `parallel-git-repo fetch && parallel-git-repo status` cannot tell that `fetch` failed, and a failing job is still reported as green. Comparable tools (mani, mr, git-xargs) all propagate failure.

## What

- `runner.Run` counts per-repo `command.Run()` failures with an `atomic.Int32` (race-safe across the goroutines) and returns the count.
- `runCommand` propagates it; `main` exits `1` when it is `> 0`.
- An unknown group is now treated as a failure so every failure mode ends non-zero. Unknown commands already exit non-zero via the existing `log.Fatalf`.

Tests cover the failure count, the zero-failure success path, and the unknown-group case; the whole suite passes with `-race`.

Closes #40

> Note: based on `test/drop-assertgo` since it depends on that test setup. Retarget to `master` once that branch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)