### PR TITLE
List available groups when -g references an unknown one

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -201,6 +202,15 @@ func (config *configuration) ListRepositories() map[string][]string {
 	return result
 }
 
+func sortedKeys(m map[string][]string) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
 func toStringArray(values []interface{}) []string {
 	result := make([]string, len(values))
 	for i, value := range values {
@@ -244,37 +254,33 @@ func newRunner(command runnableCommand, repos repositories) *runner {
 
 func (runner *runner) Run(args []string, group string) int {
 	var failures atomic.Int32
-	found := false
 	wg := sync.WaitGroup{}
-	for key, repos := range runner.repos.ListRepositories() {
-		if key == group {
-			found = true
-			for _, repo := range repos {
-				wg.Add(1)
-				go func(repo string) {
-					defer wg.Done()
-					output := new(bytes.Buffer)
+	all := runner.repos.ListRepositories()
+	repos, found := all[group]
+	if !found {
+		fmt.Fprintf(os.Stderr, "Unknown group %q, available groups: %s\n", group, strings.Join(sortedKeys(all), ", "))
+		return 1
+	}
+	for _, repo := range repos {
+		wg.Add(1)
+		go func(repo string) {
+			defer wg.Done()
+			output := new(bytes.Buffer)
 
-					command := exec.Command(runner.runnableCommand.Executable(), forwardArgs(runner.runnableCommand.Options(), args)...)
-					command.Stdout = output
-					command.Stderr = output
-					command.Dir = repo
-					err := command.Run()
-					if err != nil {
-						failures.Add(1)
-					}
-
-					fmt.Fprintln(runner.writer, filepath.Base(repo)+": "+runner.runnableCommand.Output(strings.TrimSpace(output.String()), err))
-				}(repo)
+			command := exec.Command(runner.runnableCommand.Executable(), forwardArgs(runner.runnableCommand.Options(), args)...)
+			command.Stdout = output
+			command.Stderr = output
+			command.Dir = repo
+			err := command.Run()
+			if err != nil {
+				failures.Add(1)
 			}
-		}
+
+			fmt.Fprintln(runner.writer, filepath.Base(repo)+": "+runner.runnableCommand.Output(strings.TrimSpace(output.String()), err))
+		}(repo)
 	}
 	wg.Wait()
 
-	if !found {
-		fmt.Fprintf(os.Stderr, "Unknown group %q, run `list` to show available groups.\n", group)
-		return 1
-	}
 	return int(failures.Load())
 }
 


### PR DESCRIPTION
## What

When `-g` references a group that doesn't exist, the error now lists the available groups inline:

```
Unknown group "typo", available groups: default, work
```

Previously it told the user to *"run `list`"* — an extra command just to recover from a typo. Listing the groups in the message lets the user fix it in one step.

## Why

Follow-up to the unknown-group guard from #41: failing loudly is done, but recovery still cost an extra command. Showing the valid names where the mistake is reported closes that gap.

The guard also now looks the group up directly in the map instead of scanning every entry with a `found` flag — which conveniently gives us the key set for the suggestion.

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)