### PR TITLE
Accept multiple groups and -g all

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ maven-notifier: ✔
 
     parallel-git-repo -g=notifier status
 
+Pass several comma-separated groups, or `all` to run over every group (repositories shared by several groups are only run once):
+
+    parallel-git-repo -g=notifier,maven status
+    parallel-git-repo -g=all fetch
+
 ### Limit how many commands run in parallel
 
 By default at most 8 commands run at once. Use `-j` to change the limit (`-j 1` runs sequentially):

--- a/main.go
+++ b/main.go
@@ -266,10 +266,9 @@ func newRunner(command runnableCommand, repos repositories) *runner {
 func (runner *runner) Run(args []string, group string) int {
 	var failures atomic.Int32
 	wg := sync.WaitGroup{}
-	all := runner.repos.ListRepositories()
-	repos, found := all[group]
-	if !found {
-		fmt.Fprintf(os.Stderr, "Unknown group %q, available groups: %s\n", group, strings.Join(sortedKeys(all), ", "))
+	repos, err := selectRepositories(runner.repos.ListRepositories(), group)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
 		return 1
 	}
 
@@ -324,6 +323,35 @@ func (runner *runner) Run(args []string, group string) int {
 	wg.Wait()
 
 	return int(failures.Load())
+}
+
+// selectRepositories resolves a group specifier into the deduplicated list of
+// repositories to run against. The specifier may name several comma-separated
+// groups, and the special value "all" selects every group. A repository listed
+// in more than one selected group is kept once, in first-seen order. An unknown
+// group name is an error.
+func selectRepositories(all map[string][]string, group string) ([]string, error) {
+	names := strings.Split(group, ",")
+	if group == "all" {
+		names = sortedKeys(all)
+	}
+
+	seen := make(map[string]struct{})
+	var repos []string
+	for _, name := range names {
+		members, found := all[name]
+		if !found {
+			return nil, fmt.Errorf("Unknown group %q, available groups: %s", name, strings.Join(sortedKeys(all), ", "))
+		}
+		for _, repo := range members {
+			if _, dup := seen[repo]; dup {
+				continue
+			}
+			seen[repo] = struct{}{}
+			repos = append(repos, repo)
+		}
+	}
+	return repos, nil
 }
 
 var option = regexp.MustCompile(`\$([0-9]+)`)

--- a/main_test.go
+++ b/main_test.go
@@ -196,6 +196,38 @@ func TestRunTimesOutAHungCommand(t *testing.T) {
 	}
 }
 
+func TestSelectRepositories(t *testing.T) {
+	all := map[string][]string{
+		"default":  {"/a", "/b"},
+		"notifier": {"/b", "/c"},
+		"maven":    {"/d"},
+	}
+
+	if _, err := selectRepositories(all, "nope"); err == nil {
+		t.Error("expected an error for an unknown group")
+	}
+
+	comma, err := selectRepositories(all, "notifier,maven")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEqual(t, strings.Join(comma, ","), "/b,/c,/d")
+
+	// A repo shared by two selected groups is kept once.
+	shared, err := selectRepositories(all, "default,notifier")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEqual(t, strings.Join(shared, ","), "/a,/b,/c")
+
+	// "all" fans out over every group, deterministically and deduplicated.
+	every, err := selectRepositories(all, "all")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assertEqual(t, strings.Join(every, ","), "/a,/b,/d,/c")
+}
+
 func TestForwardArgsLeavesPlaceholderWhenArgumentIsMissing(t *testing.T) {
 	result := forwardArgs([]string{"$1", "$3"}, []string{"only-first"})
 


### PR DESCRIPTION
## Why

`-g` matched a single group exactly, so running a command over *all* repositories, or over two groups at once, meant either duplicating paths into the `default` group or launching the tool once per group. The everyday "morning fetch" concerns every repository, and comparable tools (`gita fetch`, `mani run --all`) treat this as the common case.

## What

`Run` now resolves the `-g` value into a set of groups instead of a single lookup:

- split the value on commas (`-g notifier,maven`)
- special-case `all` to select every group (`-g all`)
- deduplicate repositories, so one shared between selected groups still runs once, in first-seen order
- unknown group names remain an error, listing the available groups

Extracted into a `selectRepositories` helper with unit coverage; README updated.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)