### PR TITLE
Run commands with shell metacharacters through /bin/sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ Also define commands that you want to run on these repositories:
 
 This is a [`TOML`](https://github.com/toml-lang/toml) file.
 
+A command that uses shell features — quoted arguments, pipes, chaining (`&&`, `;`) or redirection — is run through `/bin/sh`, so it behaves as you would type it in a terminal:
+
+```
+[commands]
+  gone = "git branch --merged | grep -v master"
+  sync = "git fetch -p && git pull"
+```
+
+Plain commands (no shell metacharacters) are executed directly, without a shell. In both cases the `$@` and `$1`, `$2`… placeholders are replaced with the arguments you pass on the command line.
+
 ## Usage
 
 ### List available commands:

--- a/main.go
+++ b/main.go
@@ -165,13 +165,33 @@ func runCommand(config *configuration, args []string, group string) int {
 		if !ok {
 			log.Fatalf("Unknown command %q, run with -h to list available commands.", commandName)
 		}
-		toExec = strings.Split(command, " ")
+		if needsShell(command) {
+			// A naive split on spaces cannot express quoted arguments, pipes or
+			// chaining, so route these through the shell. User arguments arrive as
+			// the shell's "$@", matching the $@ placeholder plain commands use.
+			if !strings.Contains(command, "$@") {
+				command += ` "$@"`
+			}
+			// The trailing $@ is a placeholder token forwardArgs expands into the
+			// shell's positional parameters ($1, $2, "$@") after the sh name.
+			toExec = []string{"/bin/sh", "-c", command, "sh", "$@"}
+		} else {
+			toExec = strings.Split(command, " ")
+		}
 	}
 
 	runner := newRunner(&run{ToExec: toExec, Quiet: quiet}, config)
 	runner.jobs = jobs
 	runner.timeout = timeout
 	return runner.Run(args[1:], group)
+}
+
+// needsShell reports whether a configured command relies on shell features
+// (quotes, pipes, chaining, redirection, subshells) that a plain space-split
+// cannot honour. The $N/$@ placeholders are deliberately excluded so plain
+// commands keep the faster direct-exec path.
+func needsShell(command string) bool {
+	return strings.ContainsAny(command, "|&;<>()`\"'")
 }
 
 type repositories interface {

--- a/main_test.go
+++ b/main_test.go
@@ -235,6 +235,44 @@ func TestForwardArgsLeavesPlaceholderWhenArgumentIsMissing(t *testing.T) {
 	assertEqual(t, result[1], "$3")
 }
 
+func TestNeedsShell(t *testing.T) {
+	shell := []string{
+		`git commit -m "two words"`,
+		"git branch --merged | grep -v master",
+		"git fetch -p && git pull",
+	}
+	for _, c := range shell {
+		if !needsShell(c) {
+			t.Errorf("needsShell(%q) = false, want true", c)
+		}
+	}
+	for _, c := range []string{"git pull", "git push $@", "mvn versions:set -DnewVersion=$1"} {
+		if needsShell(c) {
+			t.Errorf("needsShell(%q) = true, want false", c)
+		}
+	}
+}
+
+// shellCommand mirrors how runCommand wraps a metacharacter-bearing command so
+// the routing can be exercised end-to-end through the runner.
+type shellCommand struct{ toExec []string }
+
+func (c *shellCommand) Executable() string              { return c.toExec[0] }
+func (c *shellCommand) Options() []string               { return c.toExec[1:] }
+func (c *shellCommand) Output(o string, _ error) string { return o }
+
+func TestShellCommandHonoursQuotesPipesAndArguments(t *testing.T) {
+	output := new(bytes.Buffer)
+	repos := &SingleTempRepository{}
+	// Quoted argument kept whole, then piped, then a forwarded "$@".
+	runner := newRunner(&shellCommand{[]string{"/bin/sh", "-c", `echo "two words" | tr a-z A-Z && echo "$@"`, "sh", "$@"}}, repos)
+	runner.writer = output
+
+	runner.Run([]string{"forwarded"}, "default")
+
+	assertEqual(t, output.String(), repos.Dir()+": TWO WORDS\nforwarded\n")
+}
+
 func TestListRepositories(t *testing.T) {
 	dir := t.TempDir()
 	config := `


### PR DESCRIPTION
## Why

Configured commands were tokenized with a naive `strings.Split(command, " ")`, which breaks the things users hit within the first week of real usage:

- **quoted arguments**: `git commit -m "two words"` split into `-m`, `"two`, `words"`
- **pipes**: `git branch --merged | grep -v master` passed the `|` as a literal argument to git
- **chaining**: `git fetch -p && git pull`

myrepos and mani define commands as shell for exactly this reason.

## What

Commands containing a shell metacharacter (``| & ; < > ( ) ` " '``) are now executed via `/bin/sh -c`. Plain commands keep the direct-exec path, so they pay no shell overhead. User arguments reach the shell as `"$@"`, consistent with the existing `$@` placeholder; the `$N` placeholders still work in both paths.

```toml
[commands]
  gone = "git branch --merged | grep -v master"
  sync = "git fetch -p && git pull"
```

## Tests

- `TestNeedsShell` — metachar detection, and that `$@`/`$1` placeholders don't trip it
- `TestShellCommandHonoursQuotesPipesAndArguments` — quotes, pipe and `$@` forwarding end-to-end through the runner

Verified against a real repo: pipe, quoted-arg-plus-chaining, and argument forwarding all behave as typed.

Fixes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)