### PR TITLE
Make `list` honour the -g group flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -129,7 +129,10 @@ func main() {
 
 	configuration := newConfiguration(home)
 	if args[0] == "list" {
-		repos := configuration.ListRepositories()
+		repos, err := filterGroup(configuration.ListRepositories(), group)
+		if err != nil {
+			log.Fatal(err)
+		}
 		for key, repos := range repos {
 			fmt.Printf("%s:\n", key)
 			for _, repo := range repos {
@@ -193,6 +196,21 @@ func addRepository(homeDir string, args []string) error {
 	}
 	fmt.Printf("Added %s to group %q\n", path, *group)
 	return nil
+}
+
+// filterGroup narrows the group map to the requested group so `list` previews
+// the same repositories `run` would touch, instead of always dumping every
+// group. -g left at its default keeps the whole config; an explicit unknown
+// group is an error, mirroring selectRepositories.
+func filterGroup(all map[string][]string, group string) (map[string][]string, error) {
+	if group == "default" {
+		return all, nil
+	}
+	members, found := all[group]
+	if !found {
+		return nil, fmt.Errorf("Unknown group %q, available groups: %s", group, strings.Join(sortedKeys(all), ", "))
+	}
+	return map[string][]string{group: members}, nil
 }
 
 func listCommands() string {

--- a/main_test.go
+++ b/main_test.go
@@ -228,6 +228,37 @@ func TestSelectRepositories(t *testing.T) {
 	assertEqual(t, strings.Join(every, ","), "/a,/b,/d,/c")
 }
 
+func TestFilterGroup(t *testing.T) {
+	all := map[string][]string{
+		"default":  {"/a"},
+		"notifier": {"/b", "/c"},
+	}
+
+	// Default keeps every group.
+	if got := len(mustFilter(t, all, "default")); got != 2 {
+		t.Errorf("default should list every group, got %d", got)
+	}
+
+	// An explicit group lists only that group.
+	only := mustFilter(t, all, "notifier")
+	if len(only) != 1 || strings.Join(only["notifier"], ",") != "/b,/c" {
+		t.Errorf("expected only notifier group, got %v", only)
+	}
+
+	if _, err := filterGroup(all, "nope"); err == nil {
+		t.Error("expected an error for an unknown group")
+	}
+}
+
+func mustFilter(t *testing.T, all map[string][]string, group string) map[string][]string {
+	t.Helper()
+	got, err := filterGroup(all, group)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return got
+}
+
 func TestForwardArgsLeavesPlaceholderWhenArgumentIsMissing(t *testing.T) {
 	result := forwardArgs([]string{"$1", "$3"}, []string{"only-first"})
 


### PR DESCRIPTION
## Problem

`parallel-git-repo -g notifier list` printed every group and every repository. The `list` branch iterated over the whole map and ignored `-g`, so it couldn't preview which repositories a command would actually run against.

## Fix

Filter the map to the requested group before printing (`filterGroup`):

- `-g` left at its default → lists everything (unchanged).
- explicit group → lists only that group.
- explicit unknown group → error, reusing the same message as `selectRepositories` so `run` and `list` reject the same input.

Fixes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)