### PR TITLE
Sort map-backed output for deterministic ordering

### DIFF
--- a/main.go
+++ b/main.go
@@ -133,9 +133,9 @@ func main() {
 		if err != nil {
 			log.Fatal(err)
 		}
-		for key, repos := range repos {
+		for _, key := range sortedKeys(repos) {
 			fmt.Printf("%s:\n", key)
-			for _, repo := range repos {
+			for _, repo := range repos[key] {
 				fmt.Printf("  - %s\n", repo)
 			}
 		}
@@ -230,8 +230,8 @@ func listCommands() string {
 	result := fmt.Sprintf("  %-"+strconv.Itoa(maxSize)+"s	%s\n", "run", "run an arbitrary command")
 	result += fmt.Sprintf("  %-"+strconv.Itoa(maxSize)+"s	%s\n", "list", "list repositories where command will be run")
 	result += fmt.Sprintf("  %-"+strconv.Itoa(maxSize)+"s	%s\n", "add", "register the current (or given) repository in a group")
-	for key, value := range commands {
-		result += fmt.Sprintf("  %-"+strconv.Itoa(maxSize)+"s	%s\n", key, value)
+	for _, key := range sortedKeys(commands) {
+		result += fmt.Sprintf("  %-"+strconv.Itoa(maxSize)+"s	%s\n", key, commands[key])
 	}
 
 	return result
@@ -312,7 +312,7 @@ func (config *configuration) ListRepositories() map[string][]string {
 	return result
 }
 
-func sortedKeys(m map[string][]string) []string {
+func sortedKeys[V any](m map[string]V) []string {
 	keys := make([]string, 0, len(m))
 	for key := range m {
 		keys = append(keys, key)


### PR DESCRIPTION
## Why

`list` and the `-h` command listing iterated directly over Go maps, whose iteration order is randomised on every run. Groups and command aliases showed up in a different order on each invocation — output that looks broken, is hard to scan, and can't be diffed or tested reliably.

## What

Sort the keys before iterating in both places. `sortedKeys` is now generic so it serves both the group map (`map[string][]string`) and the command map (`map[string]string`) without a second copy. Repository lists within a group keep their TOML order, which `toml.Tree.Keys()` already preserves.

Fixes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)