### PR TITLE
Allow configuring the configuration file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ Download the archive for your platform from the [latest release](https://github.
 
 ## Configuration
 
-Configure the repositories list where command will be run in `$HOME/.parallel-git-repositories`:
+Configure the repositories list where command will be run in `$HOME/.parallel-git-repositories`.
+
+Point to a different file with the `-c` flag or the `PARALLEL_GIT_REPO_CONFIG` environment variable (flag wins, then env var, then the default above). This lets a team version its config inside a repository, or keep separate work and personal setups:
+
+```
+$ parallel-git-repo -c ./team-repos.toml -g all status
+$ PARALLEL_GIT_REPO_CONFIG=~/work.toml parallel-git-repo fetch
+```
 
 ```
 [repositories]

--- a/main.go
+++ b/main.go
@@ -59,7 +59,22 @@ var (
 	jobs         int
 	timeout      time.Duration
 	stream       bool
+	configFlag   string
 )
+
+// configFile resolves the configuration file path: the -c flag wins, then the
+// PARALLEL_GIT_REPO_CONFIG environment variable, then the historical
+// $HOME/.parallel-git-repositories. A configurable path lets a team version its
+// config inside a repository and keeps separate work/personal setups apart.
+func configFile() string {
+	if configFlag != "" {
+		return configFlag
+	}
+	if env := os.Getenv("PARALLEL_GIT_REPO_CONFIG"); env != "" {
+		return env
+	}
+	return home + "/.parallel-git-repositories"
+}
 
 const help = `NAME:
   Parallel Git Repositories - Execute commands on multiple Git repositories in parallel!
@@ -93,6 +108,7 @@ func main() {
 	flag.IntVar(&jobs, "j", 8, "maximum number of commands run in parallel")
 	flag.DurationVar(&timeout, "timeout", 60*time.Second, "kill a command that runs longer than this (0 disables)")
 	flag.BoolVar(&stream, "stream", false, "stream each repository's output live, prefixed with its name, instead of buffering whole blocks")
+	flag.StringVar(&configFlag, "c", "", "path to the configuration file (defaults to $PARALLEL_GIT_REPO_CONFIG, then $HOME/.parallel-git-repositories)")
 
 	var group string
 	flag.StringVar(&group, "g", "default", "execute command for a specific repositories group")
@@ -123,13 +139,13 @@ func main() {
 	if args[0] == "add" {
 		// Handled before newConfiguration so a missing or hand-broken config
 		// file doesn't block the very command meant to write it.
-		if err := addRepository(home, args[1:]); err != nil {
+		if err := addRepository(configFile(), args[1:]); err != nil {
 			log.Fatal(err)
 		}
 		return
 	}
 
-	configuration := newConfiguration(home)
+	configuration := newConfiguration(configFile())
 	if args[0] == "list" {
 		repos, err := filterGroup(configuration.ListRepositories(), group)
 		if err != nil {
@@ -151,7 +167,7 @@ func main() {
 // invocation fatal). The path defaults to the current directory and the group
 // to "default"; a missing group is created and the rest of the file (other
 // groups, commands) is preserved.
-func addRepository(homeDir string, args []string) error {
+func addRepository(file string, args []string) error {
 	fs := flag.NewFlagSet("add", flag.ContinueOnError)
 	group := fs.String("g", "default", "group to add the repository to")
 	if err := fs.Parse(args); err != nil {
@@ -172,7 +188,6 @@ func addRepository(homeDir string, args []string) error {
 		return fmt.Errorf("%s is not a Git repository", path)
 	}
 
-	file := homeDir + "/.parallel-git-repositories"
 	tree, err := toml.LoadFile(file)
 	if os.IsNotExist(err) {
 		tree, err = toml.Load("")
@@ -216,7 +231,7 @@ func filterGroup(all map[string][]string, group string) (map[string][]string, er
 }
 
 func listCommands() string {
-	config, err := tryNewConfiguration(home)
+	config, err := tryNewConfiguration(configFile())
 	commands := make(map[string]string)
 	if err == nil {
 		commands = config.ListCommands()
@@ -287,16 +302,16 @@ type configuration struct {
 	content *toml.Tree
 }
 
-func newConfiguration(homeDir string) *configuration {
-	config, err := tryNewConfiguration(homeDir)
+func newConfiguration(file string) *configuration {
+	config, err := tryNewConfiguration(file)
 	if err != nil {
-		log.Fatalf("Can't read configuration file %s/.parallel-git-repositories, verify that the file is valid...\n%v", homeDir, err)
+		log.Fatalf("Can't read configuration file %s, verify that the file is valid...\n%v", file, err)
 	}
 	return config
 }
 
-func tryNewConfiguration(homeDir string) (*configuration, error) {
-	config, err := toml.LoadFile(homeDir + "/.parallel-git-repositories")
+func tryNewConfiguration(file string) (*configuration, error) {
+	config, err := toml.LoadFile(file)
 	if err != nil {
 		return nil, err
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -332,8 +332,9 @@ func TestListRepositories(t *testing.T) {
     "/Users/jcgay/dev/buildplan-maven-plugin",
   ]
 `
-	os.WriteFile(dir+"/.parallel-git-repositories", []byte(config), 0644)
-	repos := newConfiguration(dir)
+	file := dir + "/.parallel-git-repositories"
+	os.WriteFile(file, []byte(config), 0644)
+	repos := newConfiguration(file)
 
 	result := repos.ListRepositories()
 
@@ -347,17 +348,17 @@ func TestListRepositories(t *testing.T) {
 }
 
 func TestAddRegistersRepository(t *testing.T) {
-	home := t.TempDir()
-	os.WriteFile(home+"/.parallel-git-repositories", []byte("[repositories]\n  default = [\"/existing\"]\n[commands]\n  pull = \"git pull\"\n"), 0644)
+	file := t.TempDir() + "/.parallel-git-repositories"
+	os.WriteFile(file, []byte("[repositories]\n  default = [\"/existing\"]\n[commands]\n  pull = \"git pull\"\n"), 0644)
 
 	repo := t.TempDir()
 	os.Mkdir(filepath.Join(repo, ".git"), 0755)
 
-	if err := addRepository(home, []string{"-g", "work", repo}); err != nil {
+	if err := addRepository(file, []string{"-g", "work", repo}); err != nil {
 		t.Fatal(err)
 	}
 
-	config := newConfiguration(home)
+	config := newConfiguration(file)
 	if got := config.ListRepositories()["work"]; len(got) != 1 || got[0] != repo {
 		t.Errorf("got %v, want [%s]", got, repo)
 	}
@@ -369,13 +370,29 @@ func TestAddRegistersRepository(t *testing.T) {
 		t.Error("commands section was lost")
 	}
 
-	if err := addRepository(home, []string{"-g", "work", repo}); err == nil {
+	if err := addRepository(file, []string{"-g", "work", repo}); err == nil {
 		t.Error("expected an error for a duplicate repository")
 	}
 
-	if err := addRepository(home, []string{t.TempDir()}); err == nil {
+	if err := addRepository(file, []string{t.TempDir()}); err == nil {
 		t.Error("expected an error for a non-Git directory")
 	}
+}
+
+func TestConfigFilePrefersFlagThenEnvThenDefault(t *testing.T) {
+	savedHome, savedFlag := home, configFlag
+	defer func() { home, configFlag = savedHome, savedFlag }()
+
+	home = "/home/user"
+	configFlag = ""
+	os.Unsetenv("PARALLEL_GIT_REPO_CONFIG")
+	assertEqual(t, configFile(), "/home/user/.parallel-git-repositories")
+
+	t.Setenv("PARALLEL_GIT_REPO_CONFIG", "/env.toml")
+	assertEqual(t, configFile(), "/env.toml")
+
+	configFlag = "/flag.toml"
+	assertEqual(t, configFile(), "/flag.toml")
 }
 
 func TestListCommands(t *testing.T) {
@@ -389,8 +406,9 @@ func TestListCommands(t *testing.T) {
   pull = "git pull"
   current-branch = "git symbolic-ref --short HEAD"
 `
-	os.WriteFile(dir+"/.parallel-git-repositories", []byte(config), 0644)
-	commands := newConfiguration(dir)
+	file := dir + "/.parallel-git-repositories"
+	os.WriteFile(file, []byte(config), 0644)
+	commands := newConfiguration(file)
 
 	result := commands.ListCommands()
 


### PR DESCRIPTION
Closes #50.

The config path was hard-coded to `$HOME/.parallel-git-repositories`. This makes it configurable so you can version a team config inside a repository, keep separate work/personal configs, and simplify tests.

## Resolution order
`-c` flag > `PARALLEL_GIT_REPO_CONFIG` env var > `$HOME/.parallel-git-repositories`

```
$ parallel-git-repo -c ./team-repos.toml -g all status
$ PARALLEL_GIT_REPO_CONFIG=~/work.toml parallel-git-repo fetch
```

## Changes
- New `-c` flag and `configFile()` resolver.
- `tryNewConfiguration`/`newConfiguration`/`addRepository` now take the full file path instead of the home dir; tests pass a path directly rather than mutating the package-level `home`.
- README documents the flag and env var.

## Verification
`go test ./...` passes. Exercised end-to-end against a temp config: `-c` flag, env var, flag-beats-env precedence, and `add` writing to the custom file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)