### PR TITLE
Add --failed flag: hide successes and print a ✔/✘ summary

### DIFF
--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ var (
 	timeout      time.Duration
 	stream       bool
 	configFlag   string
+	failed       bool
 )
 
 // configFile resolves the configuration file path: the -c flag wins, then the
@@ -109,6 +110,7 @@ func main() {
 	flag.DurationVar(&timeout, "timeout", 60*time.Second, "kill a command that runs longer than this (0 disables)")
 	flag.BoolVar(&stream, "stream", false, "stream each repository's output live, prefixed with its name, instead of buffering whole blocks")
 	flag.StringVar(&configFlag, "c", "", "path to the configuration file (defaults to $PARALLEL_GIT_REPO_CONFIG, then $HOME/.parallel-git-repositories)")
+	flag.BoolVar(&failed, "failed", false, "only print repositories whose command failed, followed by a ✔/✘ summary line")
 
 	var group string
 	flag.StringVar(&group, "g", "default", "execute command for a specific repositories group")
@@ -283,6 +285,7 @@ func runCommand(config *configuration, args []string, group string) int {
 	runner.jobs = jobs
 	runner.timeout = timeout
 	runner.stream = stream
+	runner.failed = failed
 	return runner.Run(args[1:], group)
 }
 
@@ -373,6 +376,7 @@ type runner struct {
 	jobs    int
 	timeout time.Duration
 	stream  bool
+	failed  bool
 	// mu serialises writes to writer so lines from different repositories in
 	// stream mode land whole instead of interleaved mid-line.
 	mu sync.Mutex
@@ -468,6 +472,12 @@ func (runner *runner) Run(args []string, group string) int {
 				failures.Add(1)
 			}
 
+			// --failed drops the per-repo line for successes so the few failures
+			// aren't buried under a wall of ✔ across dozens of repositories.
+			if runner.failed && err == nil {
+				return
+			}
+
 			if runner.stream {
 				prefixed.flush()
 				// Output was already streamed live, so the summary only reports the
@@ -482,7 +492,12 @@ func (runner *runner) Run(args []string, group string) int {
 	}
 	wg.Wait()
 
-	return int(failures.Load())
+	failed := int(failures.Load())
+	if runner.failed {
+		fmt.Fprintf(runner.writer, "\n%d %s / %d %s\n", len(repos)-failed, ok, failed, ko)
+	}
+
+	return failed
 }
 
 // prefixWriter turns a stream of arbitrary write chunks into whole prefixed

--- a/main_test.go
+++ b/main_test.go
@@ -153,6 +153,40 @@ func TestRunStreamsOutputPrefixedWithRepositoryName(t *testing.T) {
 	}
 }
 
+func TestRunFailedHidesSuccessesAndPrintsSummary(t *testing.T) {
+	output := new(bytes.Buffer)
+	repos := &SingleTempRepository{}
+
+	runner := newRunner(&PrintArgumentsCommand{}, repos)
+	runner.writer = output
+	runner.failed = true
+	runner.Run([]string{"hello"}, "default")
+
+	if strings.Contains(output.String(), repos.Dir()) {
+		t.Errorf("--failed should hide successful repositories, got %q", output.String())
+	}
+	if !strings.Contains(output.String(), "1 ✔ / 0 ✘") {
+		t.Errorf("expected a ✔/✘ summary line, got %q", output.String())
+	}
+}
+
+func TestRunFailedKeepsFailingRepositories(t *testing.T) {
+	output := new(bytes.Buffer)
+	repos := &SingleTempRepository{}
+
+	runner := newRunner(&FailingCommand{}, repos)
+	runner.writer = output
+	runner.failed = true
+	runner.Run(nil, "default")
+
+	if !strings.Contains(output.String(), repos.Dir()) {
+		t.Errorf("--failed should keep failing repositories, got %q", output.String())
+	}
+	if !strings.Contains(output.String(), "0 ✔ / 1 ✘") {
+		t.Errorf("expected a ✔/✘ summary line, got %q", output.String())
+	}
+}
+
 type MultiRepository struct {
 	dirs []string
 }


### PR DESCRIPTION
Closes #49

## What

Adds a `--failed` global flag that suppresses the per-repository line for successful commands and prints a final `N ✔ / M ✘` summary.

```
$ parallel-git-repo -g all --failed pull
billing-api: ✘
  exit status 1
  error: cannot pull with rebase: You have unstaged changes.

28 ✔ / 2 ✘
```

## Why

Across dozens of repositories the signal (a couple of failures) is buried under a wall of ✔. `-q` already hides success *stdout* but still prints one line per repo, so the failures scroll off screen. `--failed` drops the success lines entirely and headlines the run with a ✔/✘ count.

## How

- New `-failed` bool flag, threaded through `runCommand` onto the runner.
- In the per-repo goroutine, return early (no status line) when the command succeeded and `--failed` is set — works in both buffered and `--stream` modes.
- After `wg.Wait()`, print the summary from the existing failure counter (`successes = len(repos) - failures`).

Two tests cover it: successes hidden + summary, and failures kept + summary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)